### PR TITLE
Updates for newer version of template-haskell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,41 @@
-dist-newstyle
-result
+# Haskell
+dist*
+dist-*
+**/static/tmp/
+**/static/combined/
+**/client_session_key.aes
+*.aes
+*.bak
+*.hi
+*.o
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+*.sqlite3
+*.sqlite3-shm
+*.sqlite3-wal
+.hsenv*
+cabal-dev/
+.stack-work/
+.stack-work-devel/
+yesod-devel/
+.cabal-sandbox
+cabal.sandbox.config
+.ghc.environment.*
+.HTF/
+.ghci-build-artifacts
+
+# Editors
+.DS_Store
+*.keter
+*~
+\#*
+
+# Vim
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+Session.vim
+tags

--- a/nixpkgs.json
+++ b/nixpkgs.json
@@ -1,5 +1,5 @@
 {
   "url": "https://github.com/NixOS/nixpkgs.git",
-  "ref": "nixos-20.09",
-  "rev": "bc260badaebf67442befe20fb443034d3a91f2b3"
+  "ref": "nixos-24.11",
+  "rev": "edf04b75c13c2ac0e54df5ec5c543e300f76f1c9"
 }

--- a/obfuscate.cabal
+++ b/obfuscate.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 
 name:                obfuscate
-version:             0.1.0.0
+version:             0.2.0.0
 synopsis:            A small library for obfuscating numeric IDs
 -- description:
 homepage:            https://github.com/foxhound-systems/hs-obfuscate
@@ -25,7 +25,7 @@ library
                      , persistent
                      , scientific
                      , text
-                     , template-haskell
+                     , template-haskell >= 4.18.0.0
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -43,4 +43,4 @@ test-suite obfuscate-hs-test
                      , persistent
                      , scientific
                      , text
-                     , template-haskell
+                     , template-haskell >= 4.18.0.0

--- a/src/Web/Obfuscate/TH.hs
+++ b/src/Web/Obfuscate/TH.hs
@@ -64,7 +64,7 @@ deriveObfuscate options tyName = do
             pureFn = VarE $ mkName "pure"
         (deobfuscatedBinds, deobfuscatedFields) <- fmap mconcat $ traverse assignDeobfuscatedField tys
 
-        let body = DoE $ join
+        let body = DoE Nothing $ join
                     [ fmap (\(p, e) -> BindS p e) deobfuscatedBinds
                     , [NoBindS (pureFn `AppE` (RecConE n deobfuscatedFields))]
                     ]
@@ -93,7 +93,7 @@ deriveObfuscate options tyName = do
         let ps = fmap VarP xs
         fields <- traverse obfuscateNormalField (zip xs tys)
         let body = foldl AppE (ConE (obfuscatedConstructorName n)) fields
-        pure $ Clause [VarP ctx, ConP n ps] (NormalB body) []
+        pure $ Clause [VarP ctx, ConP n mempty ps] (NormalB body) []
 
       obfuscateClause (RecC n tys) = do
         let ctx = mkName "ctx"


### PR DESCRIPTION
Fix incompatibilities with newer versions of template-haskell (>= 2.18), namely:

- The `DoE` constructor got an extra argument in `2.17` for qualified-do
- The `ConP` constructor got an extra argument in `2.18` for additional list of type applications preceding the argument patterns

As far as I can tell these are immaterial to the function of the library, so I just filled them in with `Nothing` / `mempty`.


## Other changes

- Bump nixpkgs to latest version of nixos-24.11 (ghc-9.6.6)
- Bump library version to `0.2.0.0` and specify dependency `template-haskell >= 4.18.0.0`
- Update gitignore with standard haskell/vim stuff

## Issues resolved

- Fixes #2